### PR TITLE
Introducing Singleton Pattern

### DIFF
--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -33,8 +33,6 @@ def distinct(stat, value):
 
 def timing(stat, value):
     """Set timing stat to the value provided."""
-    kind = _StatsdOp.timing
-    action = _StatsdAction(kind=kind, stat=stat, val=value)
     Client().timing(stat, value)
 
 class _Singleton(type):

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -37,12 +37,12 @@ def timing(stat, value):
 
 class _Singleton(type):
     _instance = None
-    def __call__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(_Singleton, cls).__call__(*args, **kwargs)
-        return cls._instance
+    def __call__(self, *args, **kwargs):
+        if not self._instance:
+            self._instance = super(_Singleton, self).__call__(*args, **kwargs)
+        return self._instance
 
-class Client():
+class Client(object):
     __metaclass__ = _Singleton
 
     def __init__(self):

--- a/pystatsd/test_pystastd.py
+++ b/pystatsd/test_pystastd.py
@@ -44,5 +44,10 @@ class TestPystatsd(unittest.TestCase):
     def test_timing(self):
         pystatsd.timing(stat="my.timer", value=400)
 
+    def test_singleton(self):
+        c1 = pystatsd.Client()
+        c2 = pystatsd.Client()
+        assert(c1 is c2)
+
     if __name__ == '__main__':
         unittest.main()


### PR DESCRIPTION
Some use cases within popular Python libraries require an ability to pass object references to subordinate child processes/threads (e.g. tornado).

To enable this, a singleton pattern is introduced.  API updates are illustrated in the following example:

```
import pystatsd

client = pystatsd.Client()
client.increment("test.counter", 1)
client.decrement("test.counter", 1)
client.set("test.gauge", 100)
client.timing("test.timing", 40)
```