### PR TITLE
Bumping to version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pystatsd.increment("foo.counter")
 pystatsd.decrement("foo.counter", 10)
 
 # Decrement the same counter by 1 with a sample rate of 0.5
-pystatsd.decrement("foo.counter", 0.5)
+pystatsd.decrement("foo.counter", rate=0.5)
 
 # Set the value of a gauge to 450
 pystatsd.set("foo.gauge", 450)

--- a/README.md
+++ b/README.md
@@ -18,17 +18,13 @@ Thread Safe Statsd Python API
 import pystatsd
 
 # Increment a counter named foo.counter by 1
-pystatsd.increment("foo.counter", 1)
+pystatsd.increment("foo.counter")
 
-# Decrement the same counter by 10
-pystatsd.decrement("foo.counter", 10)
+# Decrement the same counter by 1 with a sample rate of 0.5
+pystatsd.decrement("foo.counter", 0.5)
 
 # Set the value of a gauge to 450
 pystatsd.set("foo.gauge", 450)
-
-# Increment and decrement the same gauge as before
-pystatsd.increment("foo.gauge", 100, gauge=True)
-pystatsd.decrement("foo.gauge", 10, gauge=True)
 
 # Measure a timing value
 pystatsd.timing("foo.timing", 300)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ import pystatsd
 # Increment a counter named foo.counter by 1
 pystatsd.increment("foo.counter")
 
+# Decrement the same counter by 10
+pystatsd.decrement("foo.counter", 10)
+
 # Decrement the same counter by 1 with a sample rate of 0.5
 pystatsd.decrement("foo.counter", 0.5)
 

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -176,7 +176,7 @@ class Client(object):
 
            Optionally the caller can specify both the rate for the decrement (default is 1)
            as well as whether or not to treat the given stat as a gauge"""
-	self.client.update_stats(stat, delta, rate)
+	self.client.update_stats(stat, -1 * delta, rate)
 
     def set(self, stat, value, rate=1):
         """Sets the given gauge to the value provided.

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -128,14 +128,14 @@ def increment(stat, delta=1, rate=1):
 
        Optionally the caller can specify both the rate for the increment (default is 1)
        as well as whether or not to treat the given stat as a gauge"""
-    Client().increment(stat, rate)
+    Client().increment(stat, delta, rate)
 
 def decrement(stat, delta=1, rate=1):
     """Decrements the given counter by the delta provided (1 by default).
 
        Optionally the caller can specify both the rate for the decrement (default is 1)
        as well as whether or not to treat the given stat as a gauge"""
-    Client().decrement(stat, rate)
+    Client().decrement(stat, delta, rate)
 
 def set(stat, value, rate=1):
     """Sets the given gauge to the value provided.

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -65,15 +65,13 @@ class Client(object):
     def increment(self, stat, delta=1, rate=1):
         """Increments the given counter by the delta provided (1 by default).
 
-           Optionally the caller can specify both the rate for the increment (default is 1)
-           as well as whether or not to treat the given stat as a gauge"""
+        Optionally the caller can also specify the rate for the increment (default is 1)."""
         self.client.update_stats(stat, delta, rate)
 
     def decrement(self, stat, delta=1, rate=1):
         """Decrements the given counter by the delta provided (1 by default).
 
-           Optionally the caller can specify both the rate for the decrement (default is 1)
-           as well as whether or not to treat the given stat as a gauge"""
+        Optionally the caller can also specify the rate for the decrement (default is 1)."""
         self.client.update_stats(stat, -1 * delta, rate)
 
     def set(self, stat, value, rate=1):

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -123,14 +123,14 @@ class StatsClient(object):
 
 # Added Public API
 
-def increment(stat, rate=1):
+def increment(stat, delta=1, rate=1):
     """Increments the given counter by the delta provided (1 by default).
 
        Optionally the caller can specify both the rate for the increment (default is 1)
        as well as whether or not to treat the given stat as a gauge"""
     Client().increment(stat, rate)
 
-def decrement(stat, rate=1):
+def decrement(stat, delta=1, rate=1):
     """Decrements the given counter by the delta provided (1 by default).
 
        Optionally the caller can specify both the rate for the decrement (default is 1)
@@ -163,19 +163,20 @@ class Client(object):
         prefix = os.getenv('STATSD_PREFIX', "")
         self.client = StatsClient(host, port, prefix=prefix)
 
-    def increment(self, stat, rate=1):
+    def increment(self, stat, delta=1, rate=1):
         """Increments the given counter by the delta provided (1 by default).
 
            Optionally the caller can specify both the rate for the increment (default is 1)
            as well as whether or not to treat the given stat as a gauge"""
-        self.client.increment(stat, rate)
 
-    def decrement(self, stat, rate=1):
+	self.client.update_stats(stat, delta, rate)
+
+    def decrement(self, stat, delta=1, rate=1):
         """Decrements the given counter by the delta provided (1 by default).
 
            Optionally the caller can specify both the rate for the decrement (default is 1)
            as well as whether or not to treat the given stat as a gauge"""
-        self.client.decrement(stat, rate)
+	self.client.update_stats(stat, delta, rate)
 
     def set(self, stat, value, rate=1):
         """Sets the given gauge to the value provided.

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -24,21 +24,19 @@ import os
 def increment(stat, delta=1, rate=1):
     """Increments the given counter by the delta provided (1 by default).
 
-       Optionally the caller can specify both the rate for the increment (default is 1)
-       as well as whether or not to treat the given stat as a gauge"""
+       Optionally the caller can also specify the rate for the increment (default is 1)."""
     Client().increment(stat, delta, rate)
 
 def decrement(stat, delta=1, rate=1):
     """Decrements the given counter by the delta provided (1 by default).
 
-       Optionally the caller can specify both the rate for the decrement (default is 1)
-       as well as whether or not to treat the given stat as a gauge"""
+       Optionally the caller can also specify the rate for the decrement (default is 1)."""
     Client().decrement(stat, delta, rate)
 
 def set(stat, value, rate=1):
     """Sets the given gauge to the value provided.
 
-       Optionally the caller can specify the rate for the set operation (default is 1)"""
+       Optionally the caller can specify the rate for the set operation (default is 1)."""
     Client().set(stat, value, rate)
 
 def timing(stat, value):
@@ -110,15 +108,6 @@ class _StatsClient(object):
         self.log = logging.getLogger("pystatsd.client")
         self.log.addHandler(logging.StreamHandler())
         self.udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-
-    def timing_since(self, stat, start, sample_rate=1):
-        """
-        Log timing information as the number of microseconds since the provided time float
-        >>> start = time.time()
-        >>> # do stuff
-        >>> statsd_client.timing_since('some.time', start)
-        """
-        self.timing(stat, int((time.time() - start) * 1000000), sample_rate)
 
     def timing(self, stat, time, sample_rate=1):
         """

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -69,14 +69,14 @@ class Client(object):
 
            Optionally the caller can specify both the rate for the increment (default is 1)
            as well as whether or not to treat the given stat as a gauge"""
-	self.client.update_stats(stat, delta, rate)
+        self.client.update_stats(stat, delta, rate)
 
     def decrement(self, stat, delta=1, rate=1):
         """Decrements the given counter by the delta provided (1 by default).
 
            Optionally the caller can specify both the rate for the decrement (default is 1)
            as well as whether or not to treat the given stat as a gauge"""
-	self.client.update_stats(stat, -1 * delta, rate)
+        self.client.update_stats(stat, -1 * delta, rate)
 
     def set(self, stat, value, rate=1):
         """Sets the given gauge to the value provided.

--- a/pystatsd/test_pystastd.py
+++ b/pystatsd/test_pystastd.py
@@ -19,23 +19,12 @@ class TestPystatsd(unittest.TestCase):
 
     def test_counter_increment(self):
         pystatsd.increment(stat="foo.bar")
-        pystatsd.increment(stat="foo.bar", delta=1)
-        pystatsd.increment(stat="foo.bar", delta=10, rate=0.5)
+        pystatsd.increment(stat="foo.bar")
+        pystatsd.increment(stat="foo.bar", rate=0.5)
 
     def test_counter_decrement(self):
         pystatsd.decrement(stat="bar.baz")
-        pystatsd.decrement(stat="bar.baz", delta=20)
-        pystatsd.decrement(stat="bar.baz", delta=25, rate=0.5)
-
-    def test_gauge_increment(self):
-        pystatsd.increment(stat="foo.bar", gauge=True)
-        pystatsd.increment(stat="foo.bar", delta=1, gauge=True)
-        pystatsd.increment(stat="foo.bar", delta=10, rate=0.5, gauge=True)
-
-    def test_gauge_decrement(self):
-        pystatsd.decrement(stat="bar.baz", gauge=True)
-        pystatsd.decrement(stat="bar.baz", delta=20, gauge=True)
-        pystatsd.decrement(stat="bar.baz", delta=25, rate=0.5, gauge=True)
+        pystatsd.decrement(stat="bar.baz", rate=0.5)
 
     def test_gauge_set(self):
         pystatsd.set(stat="my.gauge", value=4000)

--- a/pystatsd/test_pystastd.py
+++ b/pystatsd/test_pystastd.py
@@ -19,11 +19,12 @@ class TestPystatsd(unittest.TestCase):
 
     def test_counter_increment(self):
         pystatsd.increment(stat="foo.bar")
-        pystatsd.increment(stat="foo.bar")
+        pystatsd.increment(stat="foo.bar", delta=10)
         pystatsd.increment(stat="foo.bar", rate=0.5)
 
     def test_counter_decrement(self):
         pystatsd.decrement(stat="bar.baz")
+	pystatsd.decrement(stat="foo.bar", delta=130)
         pystatsd.decrement(stat="bar.baz", rate=0.5)
 
     def test_gauge_set(self):

--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,15 @@ def read(fname):
 
 setup(
     name="pystatsd",
-    version="1.0.0",
+    version="2.0.0",
     author="John Koenig",
     author_email="john@postmates.com",
-    description=("Thread safe statsd API"),
+    description=("One-liner statsd API"),
     license="MIT",
     keywords="python statsd",
     url="https://github.com/postmates/pystatsd",
     packages=['pystatsd'],
     install_requires=[
-        "statsd>=3.2.1",
-        "enum34>=1.1.2",
     ],
     long_description=read('README.md'),
     classifiers=[


### PR DESCRIPTION
Version 2.0.0 of the API is not backwards compatible with version 1.0.0.

Version 2.0.0 changelog:

* Sync. stat emission.  No more async worker or queue.
* Singleton class pystatsd.Client().
* Removal of non-standard gauge increment/decrement operations.
* Removal of non-standard distinct operation.