### PR TITLE
Added ephemeral option to gauge set operations.

### DIFF
--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -187,7 +187,7 @@ class _StatsClient(object):
             payload = [set_gauge]
             stats = {stat: payload}
         else:
-            prefix = '+' if value >= 0 else ''
+            prefix = '+' if value >= 0 else '-'
             set_gauge = "%s%s|g" % (prefix, value)
             payload = ["0|g", set_gauge]
             stats = {stat: payload}

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -192,7 +192,7 @@ class _StatsClient(object):
             payload = ["0|g", set_gauge]
             stats = {stat: payload}
 
-            self.send(stats, sample_rate)
+        self.send(stats, sample_rate)
 
     def update_stats(self, stats, delta, sample_rate=1, gauges=False):
         """

--- a/pystatsd/pystatsd.py
+++ b/pystatsd/pystatsd.py
@@ -182,7 +182,10 @@ class _StatsClient(object):
         >>> statsd_client.gauge('some.gauge',42)
         """
         if ephemeral:
-            self.update_stats(stat, value, sample_rate, gauges=True)
+            prefix = '-' if value < 0 else ''
+            set_gauge = "%s%s|g" % (prefix, value)
+            payload = [set_gauge]
+            stats = {stat: payload}
         else:
             prefix = '+' if value >= 0 else ''
             set_gauge = "%s%s|g" % (prefix, value)

--- a/pystatsd/test_pystastd.py
+++ b/pystatsd/test_pystastd.py
@@ -40,6 +40,7 @@ class TestPystatsd(unittest.TestCase):
     def test_gauge_set(self):
         pystatsd.set(stat="my.gauge", value=4000)
         pystatsd.set(stat="my.gauge", value=4100, rate=0.1)
+        pystatsd.set(stat="my.gauge", value=4100, ephemeral=True)
 
     def test_timing(self):
         pystatsd.timing(stat="my.timer", value=400)


### PR DESCRIPTION
The new default behavior of set is now inline with etsy/statsd in that
gauge values are atomically cleared and set via delta.  This results in
gauge values which are persisted across time deltas.

Ephemeral gauges can be set using a new, optional `ephemeral` parameter.