### PR TITLE
Introducing Support for Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,15 @@ clean-all: clean
 .PHONY: clean
 clean:
 	python setup.py clean
+	rm -rf .tox
 
 .PHONY: test
 test: check
 
 .PHONY: check
 check:
+	tox
+
+.PHONY: check-unit
+check-unit:
 	python -m unittest discover

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ check:
 
 .PHONY: check-unit
 check-unit:
-	python -m unittest discover
+	python setup.py test

--- a/README.md
+++ b/README.md
@@ -52,4 +52,10 @@ def foo():
 
 ## Running Tests
 
+### Prerequisites
+
+* tox
+
+```bash
     make check
+```

--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@ Thread Safe Statsd Python API
 ## Requirements
  
  * Python 2.7 or newer
- * statsd 3.2.1 or newer
- * enum34 1.1.2 or newer
 
 ## Building
 
+```bash
     make
+```
+
+## Installing
+
+```bash
+    make install
+```
 
 ## Usage
 

--- a/pystatsd/__init__.py
+++ b/pystatsd/__init__.py
@@ -1,4 +1,6 @@
-from pystatsd import *
+from __future__ import absolute_import
+
+from pystatsd.pystatsd import *
 
 __version__ = "2.0.1"
 __all__ = []

--- a/pystatsd/__init__.py
+++ b/pystatsd/__init__.py
@@ -1,4 +1,4 @@
 from pystatsd import *
 
 __version__ = "2.0.1"
-__all__ = [pystatsd]
+__all__ = []

--- a/pystatsd/test_pystastd.py
+++ b/pystatsd/test_pystastd.py
@@ -1,21 +1,8 @@
 import unittest
 
-import statsd
 import pystatsd
 
 class TestPystatsd(unittest.TestCase):
-
-    def test_no_exceptions_with_bad_types(self):
-        """Asserts that StatsClients are resilient to type mismatches."""
-        conn = statsd.StatsClient()
-        conn.incr("foo", "12")
-        conn.incr("foo.bar", 12, "-100")
-        conn.incr(733, 12, 1.0)
-        conn.incr("foo.gauge", 12, 1.0)
-
-        conn.gauge(12, 40)
-        conn.gauge("foo.bar", "adsfasdf")
-        conn.gauge("foo.bar", 10, "-100")
 
     def test_counter_increment(self):
         pystatsd.increment(stat="foo.bar")
@@ -57,6 +44,7 @@ class TestPystatsd(unittest.TestCase):
     def test_singleton(self):
         c1 = pystatsd.Client()
         c2 = pystatsd.Client()
+
         assert(c1 is c2)
 
     if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 from setuptools import setup
 
-
 # Utility function to read the README.md file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
 # README file and 2) it's easier to type in the README file than to put a raw
@@ -20,6 +19,7 @@ setup(
     url="https://github.com/postmates/pystatsd",
     packages=['pystatsd'],
     install_requires=[
+        'future>=0.16.0'
     ],
     long_description=read('README.md'),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,11 @@ setup(
     keywords="python statsd",
     url="https://github.com/postmates/pystatsd",
     packages=['pystatsd'],
+    test_suite='nose.collector',
+    tests_require = [
+        'nose',
+        'tox>=2.8.2'
+    ],
     install_requires=[
         'future>=0.16.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     test_suite='nose.collector',
     tests_require = [
         'nose',
-        'tox>=2.8.2'
     ],
     install_requires=[
         'future>=0.16.0'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27,py3
+
+[testenv]
+deps=
+commands=make check-unit

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 envlist = py27,py3
 
 [testenv]
+whitelist_externals = make
 deps=
 commands=make check-unit


### PR DESCRIPTION
Module remains backwards compatible with Python 2.7.  To ensure tests
run in both environments, make check now depends on tox.